### PR TITLE
_send_to_chat allow sending to channels

### DIFF
--- a/aiotg/chat.py
+++ b/aiotg/chat.py
@@ -28,6 +28,12 @@ class Chat:
         )
 
     def _send_to_chat(self, method, **options):
+        if("chat_id" in options):
+            return self.bot.api_call(
+            method,
+            **options
+        )
+        
         return self.bot.api_call(
             method,
             chat_id=str(self.id),


### PR DESCRIPTION
Default is to send to user interacting with the bot.
Wanted to be able to send to channels - being able to specify chat_id in the options dictionary.