### PR TITLE
Add methods and tests to edit only markup of the message

### DIFF
--- a/aiotg/bot.py
+++ b/aiotg/bot.py
@@ -259,6 +259,24 @@ class Bot:
             **options
         )
 
+    _edit_message_reply_markup = partialmethod(api_call, "editMessageReplyMarkup")
+
+    def edit_message_reply_markup(self, chat_id, message_id, reply_markup, **options):
+        """
+        Edit a reply markup of message in a chat
+
+        :param int chat_id: ID of the chat the message to edit is in
+        :param int message_id: ID of the message to edit
+        :param str reply_markup: New inline keyboard markup for the message
+        :param options: Additional API options
+        """
+        return self._edit_message_reply_markup(
+            chat_id=chat_id,
+            message_id=message_id,
+            reply_markup=reply_markup,
+            **options
+        )
+
     async def get_file(self, file_id):
         """
         Get basic information about a file and prepare it for downloading.

--- a/aiotg/chat.py
+++ b/aiotg/chat.py
@@ -56,6 +56,19 @@ class Chat:
             parse_mode=parse_mode
         )
 
+    def edit_reply_markup(self, message_id, markup):
+        """
+        Edit only reply markup of the message in this chat.
+
+        :param int message_id: ID of the message to edit
+        :param dict markup: Markup options
+        """
+        return self.bot.edit_message_reply_markup(
+            self.id,
+            message_id,
+            reply_markup=json.dumps(markup)
+        )
+
     def _send_to_chat(self, method, **options):
         return self.bot.api_call(
             method,

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -171,6 +171,14 @@ class MockBot:
             **kwargs
         )
 
+    def edit_message_reply_markup(self, chat_id, message_id, reply_markup, **kwargs):
+        return self.api_call(
+            "editMessageReplyMarkup",
+            message_id=message_id,
+            reply_markup=reply_markup,
+            **kwargs
+        )
+
     def get_me(self):
         return self.api_call(
             "getMe"
@@ -254,3 +262,14 @@ def test_edit_message():
     assert "editMessageText" in bot.calls
     assert bot.calls["editMessageText"]["text"] == "bye"
     assert bot.calls["editMessageText"]["message_id"] == message_id
+
+def test_edit_reply_markup():
+    bot = MockBot()
+    chat_id = 42
+    message_id = 1337
+    chat = Chat(bot, chat_id)
+
+    chat.edit_reply_markup(message_id, {'inline_keyboard': [['ok','cancel']]})
+    assert "editMessageReplyMarkup" in bot.calls
+    assert bot.calls["editMessageReplyMarkup"]["reply_markup"] == '{"inline_keyboard": [["ok", "cancel"]]}'
+    assert bot.calls["editMessageReplyMarkup"]["message_id"] == message_id


### PR DESCRIPTION
By API design we need to have this method because Telegram will produce an error every time when you trying to change only markup (i.e. inline keyboard) but not text.