### PR TITLE
RuntimeError is too broad kind of exception, replaced with TgBotApiError

### DIFF
--- a/aiotg/bot.py
+++ b/aiotg/bot.py
@@ -37,12 +37,6 @@ MESSAGE_UPDATES = [
 logger = logging.getLogger("aiotg")
 
 
-class TgBotApiError(RuntimeError):
-    def __init__(self, *args, response):
-        super().__init__(*args)
-        self.response = response
-
-
 class Bot:
     """Telegram bot framework designed for asyncio
 
@@ -347,7 +341,7 @@ class Bot:
             else:
                 err_msg = await response.read()
             logger.error(err_msg)
-            raise TgBotApiError(err_msg, response=response)
+            raise BotApiError(err_msg, response=response)
 
     async def get_me(self):
         """
@@ -643,3 +637,9 @@ class CallbackQuery:
             callback_query_id=self.query_id,
             **options
         )
+
+
+class BotApiError(RuntimeError):
+    def __init__(self, *args, response):
+        super().__init__(*args)
+        self.response = response

--- a/aiotg/bot.py
+++ b/aiotg/bot.py
@@ -37,6 +37,12 @@ MESSAGE_UPDATES = [
 logger = logging.getLogger("aiotg")
 
 
+class ApiError(RuntimeError):
+    def __init__(self, *args, response):
+        super().__init__(*args)
+        self.response = response
+
+
 class Bot:
     """Telegram bot framework designed for asyncio
 
@@ -341,7 +347,7 @@ class Bot:
             else:
                 err_msg = await response.read()
             logger.error(err_msg)
-            raise RuntimeError(err_msg)
+            raise ApiError(err_msg, response=response)
 
     async def get_me(self):
         """

--- a/aiotg/bot.py
+++ b/aiotg/bot.py
@@ -37,7 +37,7 @@ MESSAGE_UPDATES = [
 logger = logging.getLogger("aiotg")
 
 
-class ApiError(RuntimeError):
+class TgBotApiError(RuntimeError):
     def __init__(self, *args, response):
         super().__init__(*args)
         self.response = response
@@ -347,7 +347,7 @@ class Bot:
             else:
                 err_msg = await response.read()
             logger.error(err_msg)
-            raise ApiError(err_msg, response=response)
+            raise TgBotApiError(err_msg, response=response)
 
     async def get_me(self):
         """


### PR DESCRIPTION
RuntimeError was too broad kind of exception.
I've replaced it with TgBotApiError.
TgBotApiError is a subclass of RuntimeError, so back compatibility shouldn't be broken.
And added `response` field, in case if calling side wants to know details.
(for example - to distinguish Bad Request responses from others)