### PR TITLE
fix error 'TypeError: object NoneType can't be used in 'await' expres…

### DIFF
--- a/aiotg/mock.py
+++ b/aiotg/mock.py
@@ -1,6 +1,10 @@
 from . bot import Bot
 
 
+async def empty_func():
+    pass
+
+
 class MockBot(Bot):
     def __init__(self, *args, **kwargs):
         super().__init__("test_token", args, kwargs)
@@ -8,3 +12,5 @@ class MockBot(Bot):
 
     def api_call(self, method, **params):
         self.calls[method] = params
+        return empty_func()
+


### PR DESCRIPTION
fix error "TypeError: object NoneType can't be used in 'await' expression" when call MockBot.api_call in test