### PR TITLE
Fixed README example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,10 +47,12 @@ If you want to make an external request (and that's what bots usually do) just u
 
     @bot.command("bitcoin")
     async def bitcoin(chat: Chat, match):
-        url = "https://api.bitcoinaverage.com/ticker/global/USD/"
-        async with aiohttp.get(url) as s:
-            info = await s.json()
-            await chat.send_text(info["24h_avg"])
+        url = "https://apiv2.bitcoinaverage.com/indices/global/ticker/BTCUSD"
+        session = aiohttp.ClientSession()
+        response = await session.get(url)
+        info = await response.json()
+        await chat.send_text(str(info["averages"]["day"]))
+        await session.close()
 
     bot.run()
 

--- a/README.rst
+++ b/README.rst
@@ -48,11 +48,10 @@ If you want to make an external request (and that's what bots usually do) just u
     @bot.command("bitcoin")
     async def bitcoin(chat: Chat, match):
         url = "https://apiv2.bitcoinaverage.com/indices/global/ticker/BTCUSD"
-        session = aiohttp.ClientSession()
-        response = await session.get(url)
-        info = await response.json()
-        await chat.send_text(str(info["averages"]["day"]))
-        await session.close()
+        async with aiohttp.ClientSession() as session:
+            response = await session.get(url)
+            info = await response.json()
+            await chat.send_text(str(info["averages"]["day"]))
 
     bot.run()
 


### PR DESCRIPTION
as mentioned in issue #69, aiohttp.get is deprecated and removed.
also the API used in example changed and previous API is not working anymore.