### PR TITLE
Clean-up action support and check of security_token for webhook

### DIFF
--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -58,6 +58,7 @@ def test_set_webhook():
     bot = MockBot()
     bot.set_webhook(webhook_url)
     assert "setWebhook" in bot.calls
+    assert "secret_token" in bot.calls["setWebhook"]
 
 
 def test_delete_webhook():


### PR DESCRIPTION
Two small enhancements:
* an ability to execute a custom cleanup action before closing the loop (I use it to cancel scheduled async tasks and get rid of the error in the log)
* use of the `security_token` parameter of the `setWebhook` method and the `X-Telegram-Bot-Api-Secret-Token` header in updates to check if the request was actually sent by a Telegram server (no changes are required in client code, since we generate UUID if this parameter wasn't set explicitly)